### PR TITLE
Bump cloudsmith-cli to v1.18.0

### DIFF
--- a/Formula/cloudsmith-cli.rb
+++ b/Formula/cloudsmith-cli.rb
@@ -2,8 +2,8 @@
 class CloudsmithCli < Formula
   desc "Official Cloudsmith Command-Line Interface - Be Awesome. Automate Everything"
   homepage "https://docs.cloudsmith.com/developer-tools/cli"
-  url "https://github.com/cloudsmith-io/cloudsmith-cli/releases/download/v1.17.0/cloudsmith.pyz"
-  sha256 "079c5ef347febb74f7046b463343d84aa2735dc93b8e439ecd915b92ca5d1833"
+  url "https://github.com/cloudsmith-io/cloudsmith-cli/releases/download/v1.18.0/cloudsmith.pyz"
+  sha256 "e24942f58539bececc34100008872c980babca1a422ffb9830adb9c6f3767d09"
   license "Apache-2.0"
 
   # The PEX/zipapp bundles all Python dependencies, so we only need Python 3.10


### PR DESCRIPTION
This pull request updates the `cloudsmith-cli` Homebrew formula to use the latest version of the Cloudsmith CLI tool.

Version update:

* Updated the `url` and `sha256` in `cloudsmith-cli.rb` to point to version 1.18.0 of the Cloudsmith CLI, replacing the previous 1.17.0 reference.