### PR TITLE
Bump cloudsmith-cli to v1.20.1

### DIFF
--- a/Aliases/cloudsmith
+++ b/Aliases/cloudsmith
@@ -1,0 +1,1 @@
+../Formula/cloudsmith-cli.rb

--- a/Formula/cloudsmith-cli.rb
+++ b/Formula/cloudsmith-cli.rb
@@ -1,26 +1,42 @@
 # Copyright 2026 Cloudsmith Ltd
+#
+# Template for the Homebrew formula published to the Homebrew tap
+# repository. Rendered by the release workflow (publish-homebrew job);
+# do not edit the rendered copy in the tap by hand.
 class CloudsmithCli < Formula
-  desc "Official Cloudsmith Command-Line Interface - Be Awesome. Automate Everything"
+  desc "Official Cloudsmith Command-Line Interface"
   homepage "https://docs.cloudsmith.com/developer-tools/cli"
-  url "https://github.com/cloudsmith-io/cloudsmith-cli/releases/download/v1.19.0/cloudsmith.pyz"
-  sha256 "c076e4b002ee07f26774c0f8a9134f52a73b16a3fb10adb31891475485e28038"
+  version "1.20.1"
   license "Apache-2.0"
 
-  # The PEX/zipapp bundles all Python dependencies, so we only need Python 3.10
-  depends_on "python@3.10"
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/cloudsmith-cli-macos-arm64/versions/1.20.1/cloudsmith-1.20.1-macos-arm64.tar.gz"
+    sha256 "2c2580eb8725467877f2a296d675fd681abe01050099a6405d5b4c37c6f3b901"
+  elsif OS.mac? && Hardware::CPU.intel?
+    url "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/cloudsmith-cli-macos-x86_64/versions/1.20.1/cloudsmith-1.20.1-macos-x86_64.tar.gz"
+    sha256 "a8e959909caab7d8d6fac390d530cd2a4bff3e70c97e12e06e2587a5b7ddfc85"
+  elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/cloudsmith-cli-linux-aarch64-gnu/versions/1.20.1/cloudsmith-1.20.1-linux-aarch64-gnu.tar.gz"
+    sha256 "7ff869d1d059759a938d97bdc5173d7f481782dfa7677870797b8643bd09c95c"
+  elsif OS.linux? && Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
+    url "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/cloudsmith-cli-linux-x86_64-gnu/versions/1.20.1/cloudsmith-1.20.1-linux-x86_64-gnu.tar.gz"
+    sha256 "1738b6057cac7fb60dd9a6bd72fe335560ef51d93f79b052be2df379fb2fb385"
+  end
+
+  # Placed after the url stanzas: a leading livecheck url is misdetected as the
+  # stable url by audit when every real url is inside a conditional.
+  livecheck do
+    url "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/cloudsmith-cli-manifest-macos-arm64/versions/latest/manifest.txt"
+    regex(/^version=(\d+(?:\.\d+)+)$/i)
+  end
 
   def install
-    # Install the zipapp directly to libexec
-    libexec.install "cloudsmith.pyz"
-
-    # Make the zipapp executable
-    chmod 0755, libexec/"cloudsmith.pyz"
-
-    # Create a wrapper script in bin that executes the zipapp
-    (bin/"cloudsmith").write_env_script libexec/"cloudsmith.pyz", {}
+    # PyInstaller onedir bundle: the executable must stay next to _internal/.
+    libexec.install Dir["*"]
+    bin.write_exec_script libexec/"cloudsmith"
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/cloudsmith --version")
+    assert_match "CLI Package Version: #{version}", shell_output("#{bin}/cloudsmith --version")
   end
 end

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # Cloudsmith CLI Homebrew Tap
 
-This is the official Homebrew tap for installing the [Cloudsmith CLI](https://docs.cloudsmith.com/developer-tools/cli).
+This is the official Homebrew tap for the [Cloudsmith CLI](https://docs.cloudsmith.com/developer-tools/cli).
 
-The formula installs the released `cloudsmith.pyz` PEX/zipapp from [`cloudsmith-io/cloudsmith-cli`](https://github.com/cloudsmith-io/cloudsmith-cli/releases), exposes it as the `cloudsmith` command, and uses Homebrew's `python@3.10` runtime dependency to execute it.
+The formula installs the standalone Cloudsmith CLI binary: a self-contained executable with no Python dependency.
 
 ## Installation
 
+Install the CLI by using its full formula name:
+
 ```bash
-brew tap cloudsmith-io/cloudsmith-cli
-brew install cloudsmith-cli
+brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli
+```
+
+Or install it by using the shorter `cloudsmith` alias:
+
+```bash
+brew install cloudsmith-io/cloudsmith-cli/cloudsmith
 ```
 
 To upgrade an existing installation:
@@ -17,49 +24,39 @@ To upgrade an existing installation:
 brew upgrade cloudsmith-cli
 ```
 
+If you installed the CLI before v1.20.1, it was built on the Python-based `cloudsmith.pyz` zipapp. Upgrading to the standalone binary formula is automatic: Homebrew replaces the old installation with the new one. Afterward, the now-orphaned `python@3.10` dependency can be removed with:
+
+```bash
+brew autoremove
+```
+
 To verify the installed CLI:
 
 ```bash
 cloudsmith --version
 ```
 
-## Platform Support
+## Supported Platforms
 
-This formula uses the official [Cloudsmith CLI PEX/zipapp distribution](https://github.com/cloudsmith-io/cloudsmith-cli/releases), which supports:
+| Platform | Architecture |
+| --- | --- |
+| macOS | arm64 (Apple Silicon), x86_64 (Intel) |
+| Linux (glibc) | x86_64, aarch64 |
 
-- **Linux x86_64** (glibc) - Debian, Ubuntu, RHEL, CentOS
-- **Linux ARM64** (glibc) - ARM-based Linux servers
-- **Linux x86_64** (musl) - Alpine Linux
-- **Linux ARM64** (musl) - Alpine Linux ARM
-- **macOS ARM64** - Apple Silicon
+Homebrew on Linux targets glibc, so musl-based distributions such as Alpine aren't supported by this formula.
 
-**Python versions:** 3.10, 3.11, 3.12, 3.13, 3.14
+## Where the Binaries Come From
 
-For the full platform matrix, see [`.github/.platforms`](https://github.com/cloudsmith-io/cloudsmith-cli/tree/master/.github/.platforms) in the Cloudsmith CLI repository.
+The binaries are built and published by the Cloudsmith CLI release pipeline and hosted on Cloudsmith.
 
-## Bumping the CLI Version
+## More Information
 
-The normal maintainer workflow is to run the release helper from a clean, up-to-date `main` branch:
+- CLI documentation: see the [Cloudsmith CLI docs](https://docs.cloudsmith.com/developer-tools/cli).
+- CLI source and releases: see the [cloudsmith-cli repository](https://github.com/cloudsmith-io/cloudsmith-cli).
+- Formula or tap issues: file them in [this repository's issues](https://github.com/cloudsmith-io/homebrew-cloudsmith-cli/issues).
+- CLI bugs: file them in the [cloudsmith-cli repository's issues](https://github.com/cloudsmith-io/cloudsmith-cli/issues).
 
-```bash
-./scripts/bump-cloudsmith-cli.sh
-```
-
-The helper finds the latest Cloudsmith CLI release, downloads `cloudsmith.pyz`, calculates the SHA256 used by Homebrew, creates a release branch, updates `Formula/cloudsmith-cli.rb`, runs quick checks, stages the formula change, and prints the commit, push, and PR commands for final review.
-
-To bump to a specific version:
-
-```bash
-./scripts/bump-cloudsmith-cli.sh --version v1.17.0
-```
-
-Review the staged diff before running the printed commands:
-
-```bash
-git diff --cached
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full release bump workflow and local testing commands.
+For maintainer instructions on bumping the formula to a new CLI release, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
Formula update for cloudsmith-cli v1.20.1, pointing at the standalone binaries published on Cloudsmith. Checksums were verified against the release install manifests (`cloudsmith-cli-manifest-<target>` packages) before rendering.

Opened as a draft pending review. Merge with a squash merge.

Also aligned README.md in this PR to describe the standalone binary formula.
