### PR TITLE
fix: stop Homebrew rewriting bundled dylib IDs on macOS

### DIFF
--- a/.github/workflows/formula-test.yml
+++ b/.github/workflows/formula-test.yml
@@ -1,9 +1,6 @@
 # Copyright 2026 Cloudsmith Ltd
 name: Test formula on macOS
 
-# The formula ships a prebuilt PyInstaller bundle, so the things that break it
-# are Homebrew's own install-time behaviour (relocation, linking) rather than
-# anything a syntax check can see. Exercise the real lifecycle on real runners.
 on:
   pull_request:
   push:
@@ -29,9 +26,6 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_ENV_HINTS: 1
   HOMEBREW_NO_INSTALL_CLEANUP: 1
-  # The tap is assembled from this checkout rather than cloned, so Homebrew has
-  # no upstream commit to verify it against. The formula under test is this
-  # repository's own code.
   HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
 
 jobs:
@@ -39,9 +33,6 @@ jobs:
     name: ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     strategy:
-      # Both architectures are affected by relocation failures, and the Intel
-      # bundles have less Mach-O header padding to spare, so never let one
-      # architecture's result stand in for the other.
       fail-fast: false
       matrix:
         include:
@@ -55,9 +46,6 @@ jobs:
 
       - name: Install this checkout as the tap
         run: |
-          # The tap has to carry its real name. Homebrew looks preserve_rpath up
-          # through Formula[name], so under any other tap name the flag silently
-          # would not apply and the relocation guard would go untested.
           tap_dir="$(brew --repository)/Library/Taps/cloudsmith-io/homebrew-cloudsmith-cli"
           mkdir -p "$tap_dir"
           cp -R Formula Aliases "$tap_dir/"
@@ -73,8 +61,6 @@ jobs:
 
       - name: Verify install
         run: |
-          # The formula's own test block covers the binary inside the keg; this
-          # additionally proves the version on PATH, i.e. that linking worked.
           brew test cloudsmith-io/cloudsmith-cli/cloudsmith-cli
           scripts/assert-cli-version.sh "$(sed -n 's/^  version "\(.*\)"$/\1/p' Formula/cloudsmith-cli.rb)"
 
@@ -109,10 +95,7 @@ jobs:
           python3 scripts/render-formula-version.py \
             "$TAP_DIR/Formula/cloudsmith-cli.rb" \
             "$BASELINE_VERSION" "$BASELINE_SHA256_ARM64" "$BASELINE_SHA256_X86_64"
-          # Homebrew has no downgrade command, and plain `brew install` of an
-          # older formula is a silent no-op that leaves the newer version
-          # linked, so a downgrade has to uninstall first.
-          brew uninstall cloudsmith-cli
+          brew uninstall --force cloudsmith-cli
           brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli
           scripts/assert-cli-version.sh "$BASELINE_VERSION"
 

--- a/.github/workflows/formula-test.yml
+++ b/.github/workflows/formula-test.yml
@@ -102,17 +102,11 @@ jobs:
       - name: Uninstall baseline version
         run: brew uninstall cloudsmith-cli
 
+  # arm64 only: the 1.19.0 zipapp carries no macOS x86_64 native wheels, so the
+  # formula requires arm64 on macOS and there is nothing to test on Intel.
   pin-target:
-    name: pin target ${{ matrix.arch }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: macos-latest
-            arch: arm64
-          - runner: macos-15-intel
-            arch: x86_64
+    name: pin target arm64
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/formula-test.yml
+++ b/.github/workflows/formula-test.yml
@@ -102,11 +102,23 @@ jobs:
       - name: Uninstall baseline version
         run: brew uninstall cloudsmith-cli
 
-  # arm64 only: the 1.19.0 zipapp carries no macOS x86_64 native wheels, so the
-  # formula requires arm64 on macOS and there is nothing to test on Intel.
   pin-target:
-    name: pin target arm64
-    runs-on: macos-latest
+    name: pin ${{ matrix.version }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # 1.19.0 ships macOS arm64 builds only, so it has no Intel entry.
+          - runner: macos-latest
+            arch: arm64
+            version: "1.19.0"
+          - runner: macos-latest
+            arch: arm64
+            version: "1.20.1"
+          - runner: macos-15-intel
+            arch: x86_64
+            version: "1.20.1"
 
     steps:
       - uses: actions/checkout@v4
@@ -117,26 +129,25 @@ jobs:
           mkdir -p "$tap_dir"
           cp -R Formula Aliases "$tap_dir/"
           echo "TAP_DIR=$tap_dir" >> "$GITHUB_ENV"
+          echo "PIN=cloudsmith-cli@${{ matrix.version }}" >> "$GITHUB_ENV"
 
       - name: Lint pin target
         run: |
-          brew style "$TAP_DIR/Formula/cloudsmith-cli@1.19.0.rb"
-          brew audit --formula cloudsmith-io/cloudsmith-cli/cloudsmith-cli@1.19.0
+          brew style "$TAP_DIR/Formula/$PIN.rb"
+          brew audit --formula "cloudsmith-io/cloudsmith-cli/$PIN"
 
       - name: Install pin target
-        run: brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli@1.19.0
+        run: brew install "cloudsmith-io/cloudsmith-cli/$PIN"
 
       - name: Verify pin target is usable and holdable
         run: |
-          # The formula is keg_only :versioned_formula, but Homebrew auto-links a
-          # versioned keg-only formula installed on request when no other version
-          # is present, so the rollback lands on PATH without extra steps.
-          # Matched loosely: this release predates the current --version format.
+          # Matched loosely so that both the current --version format and the
+          # older one 1.19.0 predates are accepted.
           cloudsmith --version | tee /tmp/pin-version
-          grep -qF "1.19.0" /tmp/pin-version
-          brew pin cloudsmith-cli@1.19.0
-          brew list --pinned | grep -qF "cloudsmith-cli@1.19.0"
-          brew unpin cloudsmith-cli@1.19.0
+          grep -qF "${{ matrix.version }}" /tmp/pin-version
+          brew pin "$PIN"
+          brew list --pinned | grep -qF "$PIN"
+          brew unpin "$PIN"
 
       - name: Uninstall pin target
-        run: brew uninstall cloudsmith-cli@1.19.0
+        run: brew uninstall "$PIN"

--- a/.github/workflows/formula-test.yml
+++ b/.github/workflows/formula-test.yml
@@ -118,3 +118,48 @@ jobs:
 
       - name: Uninstall baseline version
         run: brew uninstall cloudsmith-cli
+
+  pin-target:
+    name: pin target ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x86_64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install this checkout as the tap
+        run: |
+          tap_dir="$(brew --repository)/Library/Taps/cloudsmith-io/homebrew-cloudsmith-cli"
+          mkdir -p "$tap_dir"
+          cp -R Formula Aliases "$tap_dir/"
+          echo "TAP_DIR=$tap_dir" >> "$GITHUB_ENV"
+
+      - name: Lint pin target
+        run: |
+          brew style "$TAP_DIR/Formula/cloudsmith-cli@1.19.0.rb"
+          brew audit --formula cloudsmith-io/cloudsmith-cli/cloudsmith-cli@1.19.0
+
+      - name: Install pin target
+        run: brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli@1.19.0
+
+      - name: Verify pin target is usable and holdable
+        run: |
+          # The formula is keg_only :versioned_formula, but Homebrew auto-links a
+          # versioned keg-only formula installed on request when no other version
+          # is present, so the rollback lands on PATH without extra steps.
+          # Matched loosely: this release predates the current --version format.
+          cloudsmith --version | tee /tmp/pin-version
+          grep -qF "1.19.0" /tmp/pin-version
+          brew pin cloudsmith-cli@1.19.0
+          brew list --pinned | grep -qF "cloudsmith-cli@1.19.0"
+          brew unpin cloudsmith-cli@1.19.0
+
+      - name: Uninstall pin target
+        run: brew uninstall cloudsmith-cli@1.19.0

--- a/.github/workflows/formula-test.yml
+++ b/.github/workflows/formula-test.yml
@@ -1,0 +1,120 @@
+# Copyright 2026 Cloudsmith Ltd
+name: Test formula on macOS
+
+# The formula ships a prebuilt PyInstaller bundle, so the things that break it
+# are Homebrew's own install-time behaviour (relocation, linking) rather than
+# anything a syntax check can see. Exercise the real lifecycle on real runners.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  # Homebrew itself changes underneath us; a scheduled run catches a formula
+  # that stops installing without this repository changing at all.
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # A fixed known-good release, used purely as the "other end" of the upgrade
+  # and downgrade transitions. This is a deliberate baseline, not "the previous
+  # release": it does not need bumping when a new version ships.
+  BASELINE_VERSION: "1.20.1"
+  BASELINE_SHA256_ARM64: "2c2580eb8725467877f2a296d675fd681abe01050099a6405d5b4c37c6f3b901"
+  BASELINE_SHA256_X86_64: "a8e959909caab7d8d6fac390d530cd2a4bff3e70c97e12e06e2587a5b7ddfc85"
+  HOMEBREW_NO_ANALYTICS: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_ENV_HINTS: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+  # The tap is assembled from this checkout rather than cloned, so Homebrew has
+  # no upstream commit to verify it against. The formula under test is this
+  # repository's own code.
+  HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
+
+jobs:
+  lifecycle:
+    name: ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # Both architectures are affected by relocation failures, and the Intel
+      # bundles have less Mach-O header padding to spare, so never let one
+      # architecture's result stand in for the other.
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x86_64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install this checkout as the tap
+        run: |
+          # The tap has to carry its real name. Homebrew looks preserve_rpath up
+          # through Formula[name], so under any other tap name the flag silently
+          # would not apply and the relocation guard would go untested.
+          tap_dir="$(brew --repository)/Library/Taps/cloudsmith-io/homebrew-cloudsmith-cli"
+          mkdir -p "$tap_dir"
+          cp -R Formula Aliases "$tap_dir/"
+          echo "TAP_DIR=$tap_dir" >> "$GITHUB_ENV"
+
+      - name: Lint formula
+        run: |
+          brew style "$TAP_DIR/Formula/cloudsmith-cli.rb"
+          brew audit --formula cloudsmith-io/cloudsmith-cli/cloudsmith-cli
+
+      - name: Install
+        run: brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli
+
+      - name: Verify install
+        run: |
+          # The formula's own test block covers the binary inside the keg; this
+          # additionally proves the version on PATH, i.e. that linking worked.
+          brew test cloudsmith-io/cloudsmith-cli/cloudsmith-cli
+          scripts/assert-cli-version.sh "$(sed -n 's/^  version "\(.*\)"$/\1/p' Formula/cloudsmith-cli.rb)"
+
+      - name: Uninstall
+        run: |
+          brew uninstall cloudsmith-cli
+          if command -v cloudsmith; then
+            echo "cloudsmith still on PATH after uninstall" >&2
+            exit 1
+          fi
+          if brew list --versions cloudsmith-cli; then
+            echo "keg still present after uninstall" >&2
+            exit 1
+          fi
+
+      - name: Install baseline version
+        run: |
+          python3 scripts/render-formula-version.py \
+            "$TAP_DIR/Formula/cloudsmith-cli.rb" \
+            "$BASELINE_VERSION" "$BASELINE_SHA256_ARM64" "$BASELINE_SHA256_X86_64"
+          brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli
+          scripts/assert-cli-version.sh "$BASELINE_VERSION"
+
+      - name: Upgrade to this formula
+        run: |
+          cp Formula/cloudsmith-cli.rb "$TAP_DIR/Formula/cloudsmith-cli.rb"
+          brew upgrade cloudsmith-io/cloudsmith-cli/cloudsmith-cli
+          scripts/assert-cli-version.sh "$(sed -n 's/^  version "\(.*\)"$/\1/p' Formula/cloudsmith-cli.rb)"
+
+      - name: Downgrade to baseline version
+        run: |
+          python3 scripts/render-formula-version.py \
+            "$TAP_DIR/Formula/cloudsmith-cli.rb" \
+            "$BASELINE_VERSION" "$BASELINE_SHA256_ARM64" "$BASELINE_SHA256_X86_64"
+          # Homebrew has no downgrade command, and plain `brew install` of an
+          # older formula is a silent no-op that leaves the newer version
+          # linked, so a downgrade has to uninstall first.
+          brew uninstall cloudsmith-cli
+          brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli
+          scripts/assert-cli-version.sh "$BASELINE_VERSION"
+
+      - name: Uninstall baseline version
+        run: brew uninstall cloudsmith-cli

--- a/Formula/cloudsmith-cli.rb
+++ b/Formula/cloudsmith-cli.rb
@@ -30,6 +30,12 @@ class CloudsmithCli < Formula
     regex(/^version=(\d+(?:\.\d+)+)$/i)
   end
 
+  # The bundled libraries are private to the PyInstaller bundle and are resolved
+  # via @rpath, so Homebrew must not rewrite their dylib IDs: the absolute Cellar
+  # path does not fit in the Mach-O header padding of prebuilt wheels such as
+  # pydantic_core, which fails the install.
+  preserve_rpath
+
   def install
     # PyInstaller onedir bundle: the executable must stay next to _internal/.
     libexec.install Dir["*"]

--- a/Formula/cloudsmith-cli@1.19.0.rb
+++ b/Formula/cloudsmith-cli@1.19.0.rb
@@ -20,8 +20,17 @@ class CloudsmithCliAT1190 < Formula
 
   def install
     libexec.install "cloudsmith.pyz"
-    chmod 0755, libexec/"cloudsmith.pyz"
-    (bin/"cloudsmith").write_env_script libexec/"cloudsmith.pyz", {}
+
+    # Run the zipapp under the interpreter this formula depends on. Its
+    # `#!/usr/bin/env python3` shebang would otherwise pick up whatever python3
+    # comes first on PATH, which on some machines is older than the 3.10 the
+    # zipapp requires.
+    python = formula_opt_bin("python@3.10")/"python3.10"
+    (bin/"cloudsmith").write <<~BASH
+      #!/bin/bash
+      exec "#{python}" "#{libexec}/cloudsmith.pyz" "$@"
+    BASH
+    chmod 0755, bin/"cloudsmith"
   end
 
   test do

--- a/Formula/cloudsmith-cli@1.19.0.rb
+++ b/Formula/cloudsmith-cli@1.19.0.rb
@@ -1,0 +1,30 @@
+# Copyright 2026 Cloudsmith Ltd
+#
+# Pinnable rollback target for the last release before the CLI switched to a
+# PyInstaller bundle. Kept so that anyone broken by a newer release can return
+# to a known-good version with `brew install cloudsmith-cli@1.19.0`, rather than
+# reconstructing an old formula out of this tap's git history.
+#
+# Intentionally frozen: this file describes 1.19.0 and should not be bumped.
+class CloudsmithCliAT1190 < Formula
+  desc "Official Cloudsmith Command-Line Interface (pinned 1.19.0)"
+  homepage "https://docs.cloudsmith.com/developer-tools/cli"
+  url "https://github.com/cloudsmith-io/cloudsmith-cli/releases/download/v1.19.0/cloudsmith.pyz"
+  sha256 "c076e4b002ee07f26774c0f8a9134f52a73b16a3fb10adb31891475485e28038"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+
+  # The PEX/zipapp bundles all Python dependencies, so we only need Python 3.10.
+  depends_on "python@3.10"
+
+  def install
+    libexec.install "cloudsmith.pyz"
+    chmod 0755, libexec/"cloudsmith.pyz"
+    (bin/"cloudsmith").write_env_script libexec/"cloudsmith.pyz", {}
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/cloudsmith --version")
+  end
+end

--- a/Formula/cloudsmith-cli@1.19.0.rb
+++ b/Formula/cloudsmith-cli@1.19.0.rb
@@ -18,6 +18,13 @@ class CloudsmithCliAT1190 < Formula
   # The PEX/zipapp bundles all Python dependencies, so we only need Python 3.10.
   depends_on "python@3.10"
 
+  # The 1.19.0 zipapp bundles native wheels for macOS arm64 only: it carries no
+  # macosx x86_64 build of rpds-py, pydantic-core or cffi, so it cannot run on an
+  # Intel Mac. Fail with that up front rather than a PEX resolution dump.
+  on_macos do
+    depends_on arch: :arm64
+  end
+
   def install
     libexec.install "cloudsmith.pyz"
 

--- a/Formula/cloudsmith-cli@1.20.1.rb
+++ b/Formula/cloudsmith-cli@1.20.1.rb
@@ -1,0 +1,40 @@
+# Copyright 2026 Cloudsmith Ltd
+#
+# Pinnable rollback target covering every supported platform. Kept alongside
+# cloudsmith-cli@1.19.0, which is the escape hatch from the PyInstaller
+# packaging but ships macOS arm64 builds only.
+#
+# Intentionally frozen: this file describes 1.20.1 and should not be bumped.
+class CloudsmithCliAT1201 < Formula
+  desc "Official Cloudsmith Command-Line Interface (pinned 1.20.1)"
+  homepage "https://docs.cloudsmith.com/developer-tools/cli"
+  version "1.20.1"
+  license "Apache-2.0"
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/cloudsmith-cli-macos-arm64/versions/1.20.1/cloudsmith-1.20.1-macos-arm64.tar.gz"
+    sha256 "2c2580eb8725467877f2a296d675fd681abe01050099a6405d5b4c37c6f3b901"
+  elsif OS.mac? && Hardware::CPU.intel?
+    url "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/cloudsmith-cli-macos-x86_64/versions/1.20.1/cloudsmith-1.20.1-macos-x86_64.tar.gz"
+    sha256 "a8e959909caab7d8d6fac390d530cd2a4bff3e70c97e12e06e2587a5b7ddfc85"
+  elsif OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/cloudsmith-cli-linux-aarch64-gnu/versions/1.20.1/cloudsmith-1.20.1-linux-aarch64-gnu.tar.gz"
+    sha256 "7ff869d1d059759a938d97bdc5173d7f481782dfa7677870797b8643bd09c95c"
+  elsif OS.linux? && Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
+    url "https://dl.cloudsmith.io/public/cloudsmith/cli/raw/names/cloudsmith-cli-linux-x86_64-gnu/versions/1.20.1/cloudsmith-1.20.1-linux-x86_64-gnu.tar.gz"
+    sha256 "1738b6057cac7fb60dd9a6bd72fe335560ef51d93f79b052be2df379fb2fb385"
+  end
+
+  keg_only :versioned_formula
+
+  preserve_rpath
+
+  def install
+    libexec.install Dir["*"]
+    bin.write_exec_script libexec/"cloudsmith"
+  end
+
+  test do
+    assert_match "CLI Package Version: #{version}", shell_output("#{bin}/cloudsmith --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -36,6 +36,43 @@ To verify the installed CLI:
 cloudsmith --version
 ```
 
+## Holding or Rolling Back a Version
+
+To stay on the version you already have and stop `brew upgrade` moving it:
+
+```bash
+brew pin cloudsmith-cli
+```
+
+Use `brew unpin cloudsmith-cli` to release it again.
+
+Homebrew has no downgrade command, and installing an older formula on top of a
+newer one does nothing: it reports that the version is already installed and
+leaves the newer one linked. A rollback therefore has to uninstall first.
+
+To roll back to 1.19.0, the last release before the standalone binary, install
+the pinned formula kept in this tap for that purpose:
+
+```bash
+brew uninstall cloudsmith-cli
+brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli@1.19.0
+brew pin cloudsmith-cli@1.19.0
+```
+
+To roll back to any other version, extract that version's formula from this
+tap's history into a tap of your own:
+
+```bash
+brew tap-new <your-org>/cloudsmith-cli-versions
+brew extract --version=1.20.1 cloudsmith-io/cloudsmith-cli/cloudsmith-cli <your-org>/cloudsmith-cli-versions
+brew uninstall cloudsmith-cli
+brew install <your-org>/cloudsmith-cli-versions/cloudsmith-cli@1.20.1
+```
+
+Note that formulae extracted for 1.20.1 or 1.20.2 predate a fix for a macOS
+install failure and will fail with `Error: Failed to fix install linkage`. Add
+`preserve_rpath` to the extracted formula to install those versions on macOS.
+
 ## Supported Platforms
 
 | Platform | Architecture |

--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ brew pin cloudsmith-cli
 
 Use `brew unpin cloudsmith-cli` to release it again.
 
-Homebrew has no downgrade command, and installing an older formula on top of a
-newer one does nothing: it reports that the version is already installed and
-leaves the newer one linked. A rollback therefore has to uninstall first.
-
 To roll back to 1.19.0, the last release before the standalone binary, install
 the pinned formula kept in this tap for that purpose:
 
@@ -68,10 +64,6 @@ brew extract --version=1.20.1 cloudsmith-io/cloudsmith-cli/cloudsmith-cli <your-
 brew uninstall cloudsmith-cli
 brew install <your-org>/cloudsmith-cli-versions/cloudsmith-cli@1.20.1
 ```
-
-Note that formulae extracted for 1.20.1 or 1.20.2 predate a fix for a macOS
-install failure and will fail with `Error: Failed to fix install linkage`. Add
-`preserve_rpath` to the extracted formula to install those versions on macOS.
 
 ## Supported Platforms
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ brew pin cloudsmith-cli
 Use `brew unpin cloudsmith-cli` to release it again.
 
 To roll back to 1.19.0, the last release before the standalone binary, install
-the pinned formula kept in this tap for that purpose:
+the pinned formula kept in this tap for that purpose. On macOS this needs Apple
+Silicon, because the 1.19.0 zipapp shipped no Intel macOS builds of its native
+dependencies:
 
 ```bash
 brew uninstall cloudsmith-cli

--- a/README.md
+++ b/README.md
@@ -46,15 +46,22 @@ brew pin cloudsmith-cli
 
 Use `brew unpin cloudsmith-cli` to release it again.
 
-To roll back to 1.19.0, the last release before the standalone binary, install
-the pinned formula kept in this tap for that purpose. On macOS this needs Apple
-Silicon, because the 1.19.0 zipapp shipped no Intel macOS builds of its native
-dependencies:
+This tap keeps two older versions as pinnable rollback targets:
+
+| Formula | Version | Platforms |
+| --- | --- | --- |
+| `cloudsmith-cli@1.20.1` | 1.20.1, standalone binary | all supported platforms |
+| `cloudsmith-cli@1.19.0` | 1.19.0, last Python zipapp release | macOS arm64 and Linux |
+
+`cloudsmith-cli@1.19.0` is unavailable on Intel macOS because that release
+shipped no Intel macOS builds of its native dependencies.
+
+To roll back, uninstall the current version and install the target:
 
 ```bash
 brew uninstall cloudsmith-cli
-brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli@1.19.0
-brew pin cloudsmith-cli@1.19.0
+brew install cloudsmith-io/cloudsmith-cli/cloudsmith-cli@1.20.1
+brew pin cloudsmith-cli@1.20.1
 ```
 
 To roll back to any other version, extract that version's formula from this

--- a/scripts/assert-cli-version.sh
+++ b/scripts/assert-cli-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cloudsmith Ltd
+#
+# Assert that the cloudsmith CLI on PATH reports an expected version.
+#
+# Deliberately resolves the binary through PATH rather than through the keg, so
+# that a formula which installs correctly but links the wrong version, or fails
+# to link at all, is still caught.
+set -euo pipefail
+
+expected="${1:?usage: assert-cli-version.sh EXPECTED_VERSION}"
+
+if ! command -v cloudsmith >/dev/null; then
+  printf 'cloudsmith is not on PATH\n' >&2
+  exit 1
+fi
+
+output="$(cloudsmith --version </dev/null)"
+actual="$(printf '%s\n' "$output" | sed -n 's/^CLI Package Version: //p')"
+
+if [ "$actual" != "$expected" ]; then
+  printf 'expected CLI version %s, got "%s"\nfull output:\n%s\n' \
+    "$expected" "$actual" "$output" >&2
+  exit 1
+fi
+
+printf 'cloudsmith on PATH reports %s\n' "$actual"

--- a/scripts/render-formula-version.py
+++ b/scripts/render-formula-version.py
@@ -4,9 +4,7 @@
 # Repoint a rendered formula at a different Cloudsmith CLI version.
 #
 # Used by the macOS formula workflow to produce the second version needed to
-# exercise upgrade and downgrade transitions. Homebrew cannot downgrade a
-# formula on its own: a downgrade is an uninstall followed by installing an
-# older formula, so CI has to be able to materialise that older formula.
+# exercise upgrade and downgrade transitions.
 #
 # Only the macOS sha256 values are rewritten, because the transitions run on
 # macOS runners. The Linux sha256 values are deliberately left untouched and

--- a/scripts/render-formula-version.py
+++ b/scripts/render-formula-version.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cloudsmith Ltd
+#
+# Repoint a rendered formula at a different Cloudsmith CLI version.
+#
+# Used by the macOS formula workflow to produce the second version needed to
+# exercise upgrade and downgrade transitions. Homebrew cannot downgrade a
+# formula on its own: a downgrade is an uninstall followed by installing an
+# older formula, so CI has to be able to materialise that older formula.
+#
+# Only the macOS sha256 values are rewritten, because the transitions run on
+# macOS runners. The Linux sha256 values are deliberately left untouched and
+# must not be relied on in the rendered output.
+import re
+import sys
+
+SHA256_LINE = re.compile(r'^(\s*sha256 ")[0-9a-f]{64}(")$')
+VERSION_LINE = re.compile(r'^  version "(.+)"$', re.MULTILINE)
+MACOS_SHA_KEYS = ("macos-arm64", "macos-x86_64")
+
+
+def rewrite(formula, version, shas):
+    """Return formula repointed at version, with macOS sha256 values replaced.
+
+    The version appears in the version stanza and in every url, so it is
+    replaced as a plain string. Each sha256 is matched to a platform by the url
+    line that precedes it, which is how the formula pairs them.
+    """
+    current_version = VERSION_LINE.search(formula)
+    if not current_version:
+        raise SystemExit("no version stanza found in formula")
+    formula = formula.replace(current_version.group(1), version)
+
+    rendered = []
+    platform = None
+    for line in formula.split("\n"):
+        if '  url "' in line:
+            platform = next((key for key in shas if key in line), None)
+        sha256 = SHA256_LINE.match(line)
+        if sha256 and platform:
+            line = f"{sha256.group(1)}{shas[platform]}{sha256.group(2)}"
+            platform = None
+        rendered.append(line)
+    return "\n".join(rendered)
+
+
+def main():
+    if len(sys.argv) != 5:
+        raise SystemExit(
+            f"usage: {sys.argv[0]} FORMULA VERSION ARM64_SHA256 X86_64_SHA256"
+        )
+    path, version, arm64_sha256, x86_64_sha256 = sys.argv[1:5]
+    shas = dict(zip(MACOS_SHA_KEYS, (arm64_sha256, x86_64_sha256)))
+
+    with open(path, encoding="utf-8") as formula:
+        rendered = rewrite(formula.read(), version, shas)
+    with open(path, "w", encoding="utf-8") as formula:
+        formula.write(rendered)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes the macOS install failure reported since 1.20.1 (ENG-13692), adds CI that would have caught it, and provides supported rollback targets (ENG-13693).

## The bug

1.20.1 changed the packaging format: a pure-Python PEX zipapp became a PyInstaller onedir bundle, so the keg now contains 65 prebuilt Mach-O files where before there were none. Homebrew rewrites the dylib ID of every one of them to an absolute Cellar path, and that name does not fit in the header padding of `pydantic_core`'s prebuilt wheel:

```
Error: Failed changing dylib ID of .../libexec/_internal/pydantic_core/_pydantic_core.cpython-312-darwin.so
  from @rpath/pydantic_core._pydantic_core.cpython-312-darwin.so
    to /opt/homebrew/opt/cloudsmith-cli/libexec/_internal/pydantic_core/pydantic_core._pydantic_core...
Error: Failed to fix install linkage
```

Measured against the real 1.20.2 artifacts — the ID needs 56 more bytes than is available:

| artifact | header slack | needed | result |
| --- | --- | --- | --- |
| arm64 `_pydantic_core.so` | 48 bytes | 56 | **fails** |
| x86_64 `_pydantic_core.so` | 32 bytes | 56 | **fails** |
| arm64 `rpds.so` | 48 bytes | 40 | passes by 8 bytes |

Both architectures are affected, and `1.20.2` is still affected. The install does link and the CLI runs, but `brew` exits non-zero, which breaks `brew upgrade` and any automation around it.

This is not an upstream `-headerpad` bug. `_pydantic_core.so` is a prebuilt maturin wheel from PyPI that PyInstaller copies verbatim, so fixing it upstream would mean building pydantic-core from source. The rewrite is also pointless: every non-system linkage in the bundle is `@rpath`-relative and private to it, and nothing outside links against them. Homebrew already skips `@rpath` install names and rpaths via `grep_v(VARIABLE_REFERENCE_RX)`; the dylib ID is the one path lacking that exemption, and `preserve_rpath` supplies it.

## CI

Nothing in CI could have caught this — the existing checks parse the formula and grep for required fields, while the failure came from Homebrew's install-time relocation. The new workflow runs the real lifecycle on arm64 and Intel:

- `lifecycle`: install, verify, uninstall, install baseline, **upgrade**, **downgrade**, uninstall
- `pin-target`: install each pinned formula, verify on PATH, pin, unpin, uninstall

The tap is assembled from the checkout under its real name on purpose: Homebrew resolves `preserve_rpath` through `Formula[name]`, so under any other tap name the flag silently would not apply and this guard would go untested. That was hit for real while developing this.

The workflow found three problems during development, all now fixed:

1. A plain `brew uninstall` before a downgrade removed only the linked keg and left the older one unlinked, so the following `brew install` no-oped and nothing was on PATH. Uninstalls all versions now.
2. The 1.19.0 zipapp's `#!/usr/bin/env python3` shebang resolved to Xcode's Python 3.9 while the zipapp requires 3.10, so the formula depended on `python@3.10` without ever using it. This was latent in the original 1.19.0 formula.
3. The 1.19.0 zipapp turned out to bundle native wheels for macOS arm64 only, so it cannot run on Intel Macs at all.

## Rollback and pinning (ENG-13693)

Homebrew cannot downgrade in place, and the obvious routes fail quietly:

| attempt | result |
| --- | --- |
| `brew install` older formula | **silent no-op**, exit 0, newer version stays linked |
| `brew link --overwrite` | links the *newest* keg |
| `brew switch` | removed from Homebrew |
| `brew uninstall` + install older | works |
| `brew install cloudsmith-cli@<version>` | works, auto-links, `brew pin` holds it |

So this keeps two versioned formulae as first-class rollback targets:

| Formula | Platforms |
| --- | --- |
| `cloudsmith-cli@1.20.1` | all supported platforms |
| `cloudsmith-cli@1.19.0` | macOS arm64 and Linux (see finding 3 above) |

Versioned formulae are keg-only, but Homebrew auto-links one installed on request when no other version is present, so a rollback lands on PATH with no extra steps. The README documents both, plus the `brew extract` route for arbitrary versions.

Emitting a versioned formula for every release from the bump script and release workflow remains open on ENG-13693; `release.yml` and `bump-cloudsmith-cli.sh` are untouched here.

## Note for reviewers

`Formula/cloudsmith-cli.rb` carries a header saying it is rendered by a `publish-homebrew` job. No such job exists in this repository, so the same `preserve_rpath` change is needed in the upstream template in `cloudsmith-io/cloudsmith-cli` or the next release will regress this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)